### PR TITLE
add rstudio pandoc to permitted executables in r-user

### DIFF
--- a/inst/profiles/debian/rapparmor.d/r-user
+++ b/inst/profiles/debian/rapparmor.d/r-user
@@ -37,4 +37,5 @@ profile r-user {
 	/usr/local/share/** mr,
 	/usr/share/** mr,
 	/usr/share/ca-certificates/** r,
+	/usr/lib/rstudio/bin/pandoc/* rix,
 }


### PR DESCRIPTION
I'm using rmarkdown to evaluate user submitted code so that the output can be presented to the user in HTML. I am very happy to just create a new profile and/or recommend that users edit the r-user profile but thought I'd submit it for possible inclusion in `r-user` in case you thought this was a good idea.